### PR TITLE
PCS-389: Fix for Producer Send and SendAsyn is blocked forever when pulsar is down

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,3 +27,5 @@ require (
 	go.uber.org/atomic v1.7.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )
+
+replace github.com/hriday-ns/pulsar-client-go/oauth2 => ./oauth2

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,6 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hriday-ns/pulsar-client-go/oauth2 v0.0.0-20210517115234-367edade2a8f h1:NcAONyELGWpN4L5PIcf3+/C68CNEnvOQraaesLVxSKw=
-github.com/hriday-ns/pulsar-client-go/oauth2 v0.0.0-20210517115234-367edade2a8f/go.mod h1:JDbkh0Yd0gqrZTsznyM8UySagOzFH27qiwEAQ9Lco9I=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jawher/mow.cli v1.0.4/go.mod h1:5hQj2V8g+qYmLUVWqu4Wuja1pI57M83EChYLVZ0sMKk=

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -70,6 +70,7 @@ type partitionProducer struct {
 	// Channel where app is posting messages to be published
 	eventsChan      chan interface{}
 	connectClosedCh chan connectionClosed
+	closeCh         chan struct{}
 
 	publishSemaphore internal.Semaphore
 	pendingQueue     internal.BlockingQueue
@@ -106,6 +107,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 		producerID:       client.rpcClient.NewProducerID(),
 		eventsChan:       make(chan interface{}, maxPendingMessages),
 		connectClosedCh:  make(chan connectionClosed, 10),
+		closeCh:          make(chan struct{}),
 		batchFlushTicker: time.NewTicker(batchingMaxPublishDelay),
 		publishSemaphore: internal.NewSemaphore(int32(maxPendingMessages)),
 		pendingQueue:     internal.NewBlockingQueue(maxPendingMessages),
@@ -292,6 +294,18 @@ func (p *partitionProducer) reconnectToBroker() {
 }
 
 func (p *partitionProducer) runEventsLoop() {
+	go func() {
+		for {
+			select {
+			case <-p.closeCh:
+				return
+			case <-p.connectClosedCh:
+				p.log.Debug("runEventsLoop will reconnect")
+				p.reconnectToBroker()
+			}
+		}
+	}()
+
 	for {
 		select {
 		case i := <-p.eventsChan:
@@ -304,8 +318,6 @@ func (p *partitionProducer) runEventsLoop() {
 				p.internalClose(v)
 				return
 			}
-		case <-p.connectClosedCh:
-			p.reconnectToBroker()
 		case <-p.batchFlushTicker.C:
 			if p.batchBuilder.IsMultiBatches() {
 				p.internalFlushCurrentBatches()
@@ -500,6 +512,7 @@ func (p *partitionProducer) failTimeoutMessages() {
 			pi.Lock()
 			if nextWaiting := diff(pi.sentAt); nextWaiting > 0 {
 				// current and subsequent items not timeout yet, stop iterating
+				p.pendingQueue.Put(item)
 				t.Reset(nextWaiting)
 				pi.Unlock()
 				break
@@ -735,6 +748,7 @@ func (p *partitionProducer) internalClose(req *closeProducer) {
 		p.log.WithError(err).Warn("Failed to close batch builder")
 	}
 
+	close(p.closeCh)
 	p.setProducerState(producerClosed)
 	p.cnx.UnregisterListener(p.producerID)
 	p.batchFlushTicker.Stop()

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -930,6 +930,53 @@ func TestSendTimeout(t *testing.T) {
 	makeHTTPCall(t, http.MethodDelete, quotaURL, "")
 }
 
+func TestSendTimeoutWithUnlimitedRetry(t *testing.T) {
+	quotaURL := adminURL + "/admin/v2/namespaces/public/default/backlogQuota"
+	quotaFmt := `{"limit": "%d", "policy": "producer_request_hold"}`
+	makeHTTPCall(t, http.MethodPost, quotaURL, fmt.Sprintf(quotaFmt, 10*1024))
+
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	topicName := newTopicName()
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            topicName,
+		SubscriptionName: "send_timeout_sub",
+	})
+	assert.Nil(t, err)
+	defer consumer.Close() // subscribe but do nothing
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:       topicName,
+		SendTimeout: 2 * time.Second,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	for i := 0; i < 10; i++ {
+		id, err := producer.Send(context.Background(), &ProducerMessage{
+			Payload: make([]byte, 1024),
+		})
+		assert.Nil(t, err)
+		assert.NotNil(t, id)
+	}
+
+	// waiting for the backlog check
+	time.Sleep((5 + 1) * time.Second)
+
+	id, err := producer.Send(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	})
+	log.Printf("Error in send : %v", err)
+	assert.NotNil(t, err)
+	assert.Nil(t, id)
+
+	makeHTTPCall(t, http.MethodDelete, quotaURL, "")
+}
+
 type noopProduceInterceptor struct{}
 
 func (noopProduceInterceptor) BeforeSend(producer Producer, message *ProducerMessage) {}


### PR DESCRIPTION
**Issue1:**  Producer Send and `SendAsyn` is blocked forever when pulsar is down if the MaxReconnectToBroker is set to unlimited retry. In case of pulsar down scenarios, within `runEventsLoop` in producer_partition.go, the call enters reconnectToBroker and remains in a forever loop until the pulsar broker connection is established. Due to this, no more events are consumed from eventsChan channel causing both `Send` and `SendAsyn` to be blocked. Due to this, the SendTimeout would also be not honoured.
**Fix:** In runEventsLoop, have a separate go-routine working on connectClosedCh channel. This way eventsChan is never blocked.

**Issue2:** The issues is with `failTimeoutMessages` method in `producer_partition` of pulsar client.  When the messages are not yet timed out, these are polled from the pending queue but never added back if these messages doesn’t exceed the timeout. Hence these messages are lost forever causing the Send method to be forever stuck on wait group. 
**Fix:** Re-queue the message back to the pending queue